### PR TITLE
Fix relative path & shebang line

### DIFF
--- a/installspam.sh
+++ b/installspam.sh
@@ -18,7 +18,7 @@ service dovecot restart
 # su -s /bin/bash debian-spamd -c "sa-learn --dump magic"
 
 cat <<EOF | sudo tee /etc/cron.daily/spamham
-#!/usr/bin/env
+#!/usr/bin/env bash
 bash /etc/dovecot/sieve/scan_reported_mails
 EOF
 

--- a/installspam.sh
+++ b/installspam.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cp -r ./sieve/conf.d/20-spamham.conf /etc/dovecot/conf.d/20-spamham.conf
+cp -r ./conf.d/20-spamham.conf /etc/dovecot/conf.d/20-spamham.conf
 cp -r ./mail/. /var/mail/
 cp -r ./sieve/. /etc/dovecot/sieve/
 mkdir -p /var/mail/imapsieve_copy


### PR DESCRIPTION
Fixes the following mistakes in the code:

1) /conf.d folder's relative path is incorrect. It is located under the root directory, not under the /sieve folder.

2) Shebang line missing the shell name after /usr/bin/env, therefore executing /etc/cron.daily/spamham cause excessive cpu usage and never ending process.