### PR TITLE
Fix spamham cron.daily script

### DIFF
--- a/installspam.sh
+++ b/installspam.sh
@@ -18,8 +18,8 @@ service dovecot restart
 # su -s /bin/bash debian-spamd -c "sa-learn --dump magic"
 
 cat <<EOF | sudo tee /etc/cron.daily/spamham
-#!/usr/bin/env
-bash /etc/dovecot/sieve/scan_reported_mails
+#!/usr/bin/env bash
+/etc/dovecot/sieve/scan_reported_mails
 EOF
 
 chmod 755 /etc/cron.daily/spamham && chown root:root /etc/cron.daily/spamham


### PR DESCRIPTION
Hello,

Yesterday I installed your software (thank you very much) and today I saw the spamham script using 100% CPU and it is because the script in /etc/cron.daily doesn't have the shell name after env, it is in the next line so the script keeps running for ever.

Thank you.

Cheers,
sahsanu